### PR TITLE
Add rules-license

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -704,6 +704,12 @@ load("//migration:maven_jar_migrator_deps.bzl", "maven_jar_migrator_repositories
 
 maven_jar_migrator_repositories()
 
+http_archive(
+    name = "rules_license",
+    sha256 = "00ccc0df21312c127ac4b12880ab0f9a26c1cff99442dc6c5a331750360de3c3",
+    url = "https://github.com/bazelbuild/rules_license/releases/download/0.0.3/rules_license-0.0.3.tar.gz",
+)
+
 # Located at the end, because it's only used in tests
 
 http_archive(

--- a/coursier.bzl
+++ b/coursier.bzl
@@ -34,6 +34,7 @@ _BUILD = """
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_jvm_external//private/rules:jvm_import.bzl", "jvm_import")
 load("@rules_jvm_external//private/rules:jetifier.bzl", "jetify_aar_import", "jetify_jvm_import")
+{rules_license_import_statement}
 {aar_import_statement}
 
 {imports}
@@ -232,6 +233,12 @@ def _get_aar_import_statement_or_empty_str(repository_ctx):
         # parse the label to validate it
         _ = Label(repository_ctx.attr.aar_import_bzl_label)
         return _AAR_IMPORT_STATEMENT % repository_ctx.attr.aar_import_bzl_label
+    else:
+        return ""
+
+def _get_rules_license_import_statement_or_empty_str(repository_ctx):
+    if repository_ctx.attr.license_json:
+        return "load(\"@rules_license//rules:license.bzl\", \"license\")"
     else:
         return ""
 
@@ -479,6 +486,18 @@ def _pinned_coursier_fetch_impl(repository_ctx):
         executable = False,
     )
 
+    license_info = {}
+    if repository_ctx.attr.license_json:
+        repository_ctx.symlink(
+            repository_ctx.path(repository_ctx.attr.license_json),
+            repository_ctx.path("imported_license_info.json"),
+        )
+        license_info = json.decode(
+            repository_ctx.read(
+                repository_ctx.path("imported_license_info.json"),
+            ),
+        )
+
     repository_ctx.report_progress("Generating BUILD targets..")
     (generated_imports, jar_versionless_target_labels) = parser.generate_imports(
         repository_ctx = repository_ctx,
@@ -499,6 +518,7 @@ def _pinned_coursier_fetch_impl(repository_ctx):
         },
         override_targets = repository_ctx.attr.override_targets,
         skip_maven_local_dependencies = False,
+        license_info = license_info,
     )
 
     repository_ctx.template(
@@ -515,6 +535,7 @@ def _pinned_coursier_fetch_impl(repository_ctx):
             repository_name = repository_ctx.name,
             imports = generated_imports,
             aar_import_statement = _get_aar_import_statement_or_empty_str(repository_ctx),
+            rules_license_import_statement = _get_rules_license_import_statement_or_empty_str(repository_ctx),
         ),
         executable = False,
     )
@@ -1045,6 +1066,18 @@ def _coursier_fetch_impl(repository_ctx):
         ),
     )
 
+    license_info = {}
+    if repository_ctx.attr.license_json:
+        repository_ctx.symlink(
+            repository_ctx.path(repository_ctx.attr.license_json),
+            repository_ctx.path("imported_license_info.json"),
+        )
+        license_info = json.decode(
+            repository_ctx.read(
+                repository_ctx.path("imported_license_info.json"),
+            ),
+        )
+
     repository_ctx.report_progress("Generating BUILD targets..")
     (generated_imports, jar_versionless_target_labels) = parser.generate_imports(
         repository_ctx = repository_ctx,
@@ -1066,6 +1099,7 @@ def _coursier_fetch_impl(repository_ctx):
         override_targets = repository_ctx.attr.override_targets,
         # Skip maven local dependencies if generating the unpinned repository
         skip_maven_local_dependencies = repository_ctx.attr.name.startswith("unpinned_"),
+        license_info = license_info,
     )
 
     # This repository rule can be either in the pinned or unpinned state, depending on when
@@ -1087,6 +1121,7 @@ def _coursier_fetch_impl(repository_ctx):
             repository_name = repository_name,
             imports = generated_imports,
             aar_import_statement = _get_aar_import_statement_or_empty_str(repository_ctx),
+            rules_license_import_statement = _get_rules_license_import_statement_or_empty_str(repository_ctx),
         ),
         executable = False,
     )
@@ -1204,6 +1239,7 @@ pinned_coursier_fetch = repository_rule(
                 "none",
             ],
         ),
+        "license_json": attr.label(doc = "JSON representing rules_license necessary metadata for applying licenses to imported artifacts"),
     },
     implementation = _pinned_coursier_fetch_impl,
 )
@@ -1266,6 +1302,7 @@ coursier_fetch = repository_rule(
                 "none",
             ],
         ),
+        "license_json": attr.label(doc = "JSON representing rules_license necessary metadata for applying licenses to imported artifacts"),
     },
     environ = [
         "JAVA_HOME",

--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -65,7 +65,7 @@ def _deduplicate_list(items):
 # tree.
 #
 # Made function public for testing.
-def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlink_artifacts, testonly_artifacts, override_targets, skip_maven_local_dependencies):
+def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlink_artifacts, testonly_artifacts, override_targets, skip_maven_local_dependencies, license_info):
     # The list of java_import/aar_import declaration strings to be joined at the end
     all_imports = []
 
@@ -334,7 +334,33 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
             target_import_string.append("\tvisibility = [%s]," % (",".join(["\"%s\"" % t for t in target_visibilities])))
             alias_visibility = "\tvisibility = [%s],\n" % (",".join(["\"%s\"" % t for t in target_visibilities]))
 
-            # 9. Finish the java_import rule.
+            # 9. Add applicable_licenses to artifact (license information taken from `license_json` passed to `maven_install`)
+            #
+            # java_import(
+            # 	name = "org_hamcrest_hamcrest_library",
+            # 	jars = ["https/repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3.jar"],
+            # 	srcjar = "https/repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3-sources.jar",
+            # 	deps = [
+            # 		":org_hamcrest_hamcrest_core",
+            # 	],
+            #   tags = [
+            #       "maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
+            #       "maven_url=https://repo1.maven.org/maven/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+            #   ],
+            #   neverlink = True,
+            #   testonly = True,
+            #   applicable_licenses = [
+            #       "LICENSE-org_hamcrest_hamcrest-library-BSD-3-Clause-Clear",
+            #   ],
+            target_import_string.append("\tapplicable_licenses = [")
+
+            if artifact["coordinates"] in license_info:
+                licenses = license_info[artifact["coordinates"]]
+                for license in licenses:
+                    target_import_string.append("\t\t\":%s\"," % (license["name"]))
+            target_import_string.append("\t],")
+
+            # 10. Finish the java_import rule.
             #
             # java_import(
             # 	name = "org_hamcrest_hamcrest_library",
@@ -354,7 +380,7 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
 
             all_imports.append("\n".join(target_import_string))
 
-            # 10. Create a versionless alias target
+            # 11. Create a versionless alias target
             #
             # alias(
             #   name = "org_hamcrest_hamcrest_library_1_3",
@@ -364,7 +390,23 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
             all_imports.append("alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n%s)" %
                                (versioned_target_alias_label, target_label, alias_visibility))
 
-            # 11. If using maven_install.json, use a genrule to copy the file from the http_file
+            # 12. If there is a corresponding license for the artifact, create a license target.
+            # https://github.com/bazelbuild/rules_license/blob/main/rules/providers.bzl#L26
+            # license(
+            #   name = "LICENSE-org_hamcrest_hamcrest-BSD-3-Clause-Clear",
+            #   copyright_notice = "Copyright 2018",
+            #   license_kinds = [
+            #     "@rules_license//licenses/spdx:BSD-3-Clause-Clear",
+            #   ],
+            #   license_text = "@//compliance/licenses:LICENSE-SPDX-BSD-3-Clause-Clear.txt",
+            #   package_name = "Hamcrest"
+            # )
+            if artifact["coordinates"] in license_info:
+                for license in license_info[artifact["coordinates"]]:
+                    all_imports.append("license(\n\tname = \"%s\",\n\tcopyright_notice = \"%s\",\n\tlicense_kinds = %s,\n\tlicense_text = \"%s\",\n\tpackage_name = \"%s\",\n)" %
+                                        (license["name"], license["copyright_notice"], license["license_kinds"], license["license_text"], license["package_name"]))
+
+            # 13. If using maven_install.json, use a genrule to copy the file from the http_file
             # repository into this repository.
             #
             # genrule(

--- a/private/rules/maven_install.bzl
+++ b/private/rules/maven_install.bzl
@@ -25,7 +25,8 @@ def maven_install(
         fail_if_repin_required = False,
         use_starlark_android_rules = False,
         aar_import_bzl_label = DEFAULT_AAR_IMPORT_LABEL,
-        duplicate_version_warning = "warn"):
+        duplicate_version_warning = "warn",
+        license_json = None):
     """Resolves and fetches artifacts transitively from Maven repositories.
 
     This macro runs a repository rule that invokes the Coursier CLI to resolve
@@ -74,6 +75,7 @@ def maven_install(
       duplicate_version_warning: What to do if an artifact is specified multiple times. If "error" then
         fail the build, if "warn" then print a message and continue, if "none" then do nothing. The default
         is "warn".
+      license_json: An optional JSON file containing a mapping of maven coordinate (`group:artifact:version`) -> rules_license: LicenseInfo attributes
     """
     repositories_json_strings = []
     for repository in parse.parse_repository_spec_list(repositories):
@@ -126,6 +128,7 @@ def maven_install(
         use_starlark_android_rules = use_starlark_android_rules,
         aar_import_bzl_label = aar_import_bzl_label,
         duplicate_version_warning = duplicate_version_warning,
+        license_json = license_json,
     )
 
     if maven_install_json != None:
@@ -149,4 +152,5 @@ def maven_install(
             use_credentials_from_home_netrc_file = use_credentials_from_home_netrc_file,
             use_starlark_android_rules = use_starlark_android_rules,
             aar_import_bzl_label = aar_import_bzl_label,
+            license_json = license_json,
         )


### PR DESCRIPTION
- Add [rules_license](https://github.com/bazelbuild/rules_license) to WORKSPACE
- Add `licenses_json` argument to `maven_install`
    - Pass-in an optional JSON file of objects that map a maven coordinate (`group:artifact:version`) -> attributes of [rules_license/LicenseInfo](https://github.com/bazelbuild/rules_license/blob/main/rules/providers.bzl#L26)